### PR TITLE
feat: create `flowtype` config

### DIFF
--- a/flowtype.js
+++ b/flowtype.js
@@ -1,0 +1,38 @@
+module.exports = {
+  parser: 'babel-eslint',
+  plugins: ['flowtype'],
+  extends: ['plugin:flowtype/recommended', 'prettier/flowtype'],
+  rules: {
+    'flowtype/array-style-complex-type': ['error', 'verbose'],
+    'flowtype/array-style-simple-type': ['error', 'shorthand'],
+    'flowtype/arrow-parens': ['error', 'as-needed'],
+    'flowtype/define-flow-type': 'error',
+    'flowtype/newline-after-flow-annotation': 'error',
+    'flowtype/no-dupe-keys': 'error',
+    'flowtype/no-existential-type': 'error',
+    'flowtype/no-flow-fix-me-comments': 'error',
+    'flowtype/no-mixed': 'warn',
+    'flowtype/no-primitive-constructor-types': 'error',
+    'flowtype/no-unused-expressions': 'error',
+    'flowtype/no-weak-types': 'error',
+    'flowtype/require-compound-type-alias': 'warn',
+    'flowtype/require-exact-type': 'warn',
+    'flowtype/require-indexer-name': ['error', 'always'],
+    'flowtype/require-inexact-type': 'error',
+    'flowtype/require-parameter-type': 'error',
+    'flowtype/require-readonly-react-props': 'error',
+    'flowtype/require-return-type': [
+      'warn',
+      'always',
+      { excludeArrowFunctions: true }
+    ],
+    'flowtype/require-types-at-top': 'warn',
+    'flowtype/require-valid-file-annotation': [
+      'error',
+      'always',
+      { annotationStyle: 'line', strict: true }
+    ],
+    'flowtype/spread-exact-type': 'error',
+    'flowtype/type-import-style': ['error', 'declaration']
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1985,6 +1985,20 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -3361,6 +3375,15 @@
           "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-flowtype": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz",
+      "integrity": "sha512-W5hLjpFfZyZsXfo5anlu7HM970JBDqbEshAJUkeczP6BFCIfJXuiIBQXyberLRtOStT0OGPF8efeTbxlHk4LpQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "eslint-plugin-jest": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "author": "Gareth Jones",
   "files": [
+    "flowtype.js",
     "index.js",
     "jest.js"
   ],
@@ -55,8 +56,10 @@
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/experimental-utils": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
+    "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-jest": "^23.4.0",
     "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.2",


### PR DESCRIPTION
🎉 

My flow is a bit rusty, so I'll run this against `theraces-react` when I've got a second, but we're leaning into TypeScript rather than Flow, so this is mainly useful for if we inherit another flow application.