### PR TITLE
chore: create `prefer-valid-rules` rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 /lib/
 /out/
 !.eslintrc.js
+!.eslintplugin/

--- a/.eslintplugin/index.js
+++ b/.eslintplugin/index.js
@@ -1,0 +1,11 @@
+const registerer = require('ts-node').register({ transpileOnly: true });
+
+registerer.enabled(true);
+
+const preferValidRules = require('./prefer-valid-rules');
+
+registerer.enabled(false);
+
+exports.rules = {
+  'prefer-valid-rules': preferValidRules
+};

--- a/.eslintplugin/prefer-valid-rules.ts
+++ b/.eslintplugin/prefer-valid-rules.ts
@@ -1,0 +1,164 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import ESLint from 'eslint';
+import * as path from 'path';
+import packageJson from '../package.json';
+
+// todo: fill-in until https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41706 is merged
+declare module 'eslint' {
+  namespace CLIEngine {
+    interface LintReport {
+      usedDeprecatedRules: DeprecatedRuleUse[];
+    }
+
+    interface DeprecatedRuleUse {
+      ruleId: string;
+      replacedBy: string[];
+    }
+  }
+}
+
+const isNameOfESLintConfigFile = (fname: string): boolean =>
+  path.relative(fname, '.') === '..' &&
+  (packageJson.files.some(name => fname.endsWith(name)) ||
+    fname.endsWith('.eslintrc.js'));
+
+const requireConfig = (config: string): Required<ESLint.Linter.Config> => ({
+  plugins: [],
+  extends: [],
+  // eslint-disable-next-line global-require
+  ...require(config)
+});
+
+const createCLIEngine = (config: ESLint.Linter.Config): ESLint.CLIEngine =>
+  new ESLint.CLIEngine({
+    useEslintrc: false,
+    cache: false,
+    envs: ['node'],
+    baseConfig: {
+      ...config,
+      parserOptions: {
+        project: 'tsconfig.eslint.json',
+        createDefaultProgram: false,
+        ecmaVersion: 2019,
+        sourceType: 'module'
+      }
+    }
+  });
+
+interface ConfigFileInfo {
+  deprecatedRules: ESLint.CLIEngine.DeprecatedRuleUse[];
+  invalidRules: Record<string, string>;
+  unknownRules: string[];
+}
+
+const collectConfigFileInfo = (configFile: string): ConfigFileInfo => {
+  const config = requireConfig(configFile);
+  const rules = { ...config.rules };
+  const invalidRules: Record<string, string> = {};
+
+  do {
+    try {
+      const results = createCLIEngine({
+        ...config,
+        rules
+      }).executeOnText('');
+
+      return {
+        deprecatedRules: results.usedDeprecatedRules,
+        unknownRules: results.results[0].messages
+          .filter(({ message }) =>
+            /Definition for rule .+ was not found\./iu.test(message)
+          )
+          .map(({ ruleId }) => ruleId)
+          .filter((ruleId): ruleId is string => !!ruleId),
+        invalidRules
+      };
+    } catch (error) {
+      const eslintError: Error = error;
+
+      const [, ruleId, reason] =
+        /Configuration for rule "(.+)" is invalid:(.+)/isu.exec(
+          eslintError.message
+        ) ?? [];
+
+      if (!ruleId) {
+        throw error;
+      }
+
+      invalidRules[ruleId] = reason;
+
+      delete rules[ruleId];
+    }
+    // eslint-disable-next-line no-constant-condition
+  } while (true);
+};
+
+// eslint-disable-next-line new-cap
+export = ESLintUtils.RuleCreator(name => name)({
+  name: __filename,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensures rules are valid.',
+      category: 'Best Practices',
+      recommended: 'error'
+    },
+    messages: {
+      deprecatedRule: 'Deprecated in favor of {{ replacedBy }}',
+      unknownRule: 'Unknown rule - Have you forgotten a plugin?',
+      invalidRule: 'The configuration for this rule is invalid: {{ reason }}'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    const fileName = context.getFilename();
+
+    if (!isNameOfESLintConfigFile(fileName)) {
+      return {};
+    }
+
+    const results = collectConfigFileInfo(fileName);
+
+    return {
+      Literal(node: TSESTree.Literal): void {
+        const ruleId = node.value;
+
+        if (typeof ruleId !== 'string') {
+          return;
+        }
+
+        if (results.unknownRules.includes(ruleId)) {
+          context.report({
+            messageId: 'unknownRule',
+            node
+          });
+
+          return;
+        }
+
+        if (ruleId in results.invalidRules) {
+          context.report({
+            data: { reason: results.invalidRules[ruleId] },
+            messageId: 'invalidRule',
+            node
+          });
+
+          return;
+        }
+
+        const deprecation = results.deprecatedRules.find(
+          rule => rule.ruleId === node.value
+        );
+
+        if (deprecation) {
+          context.report({
+            data: { replacedBy: deprecation.replacedBy.join(', ') },
+            messageId: 'deprecatedRule',
+            node
+          });
+        }
+      }
+    };
+  }
+});

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     sourceType: 'module',
     ecmaVersion: 2019
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
+  plugins: ['@typescript-eslint/eslint-plugin', 'local'],
   extends: [
     './index.js',
     'plugin:@typescript-eslint/eslint-recommended',
@@ -14,8 +14,20 @@ module.exports = {
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'prettier/@typescript-eslint'
   ],
-  overrides: [{ files: ['*.spec.*'], env: { jest: true } }],
+  overrides: [
+    { files: ['*.spec.*'], env: { jest: true } },
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/no-require-imports': 'off',
+        '@typescript-eslint/no-var-requires': 'off'
+      }
+    }
+  ],
   rules: {
+    '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/no-dynamic-delete': 'off',
+    'local/prefer-valid-rules': 'error',
     'no-sync': 'off'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,6 +1847,12 @@
         }
       }
     },
+    "arg": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3024,6 +3030,12 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
@@ -3350,6 +3362,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz",
+      "integrity": "sha1-8MBwEclf7EK/tNkJ3rtuoDXzsqQ=",
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
@@ -13227,6 +13245,19 @@
         }
       }
     },
+    "ts-node": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
+      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -13691,6 +13722,12 @@
       "requires": {
         "camelcase": "^4.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,9 +52,11 @@
     "@types/jest": "^24.9.0",
     "@types/node": "^12.12.25",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
+    "@typescript-eslint/experimental-utils": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
     "eslint": "^6.8.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^3.1.0",
     "jest": "^24.9.0",
@@ -64,6 +66,7 @@
     "prettier-config-ackama": "^0.1.2",
     "semantic-release": "^15.14.0",
     "ts-jest": "^24.3.0",
+    "ts-node": "^8.6.2",
     "typescript": "^3.7.5"
   },
   "peerDependencies": {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig.json",
   "files": [ ".eslintrc.js" ],
   "exclude": [ "node_modules" ],
-  "include": [ "test", "*.ts", "*.js" ]
+  "include": [ ".eslintplugin/*", "test", "*.ts", "*.js" ]
 }


### PR DESCRIPTION
@rabid-dan finally came up with an excuse to make a custom ESRule :joy:

It's actually a pretty sweet one too: no ones actually made a quality tool to check for checking if a rule is deprecated, and ESLint's handling of invalid configurations is to just error at the first one - it's a pretty painful method of handling things.

At some point I'll probably break this out into it's own plugin, if not into the ESLint core itself.