### PR TITLE
chore: replace module argumentation with updated `@types/eslint`

### DIFF
--- a/.eslintplugin/prefer-valid-rules.ts
+++ b/.eslintplugin/prefer-valid-rules.ts
@@ -3,20 +3,6 @@ import ESLint from 'eslint';
 import * as fs from 'fs';
 import * as path from 'path';
 
-// todo: fill-in until https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41706 is merged
-declare module 'eslint' {
-  namespace CLIEngine {
-    interface LintReport {
-      usedDeprecatedRules: DeprecatedRuleUse[];
-    }
-
-    interface DeprecatedRuleUse {
-      ruleId: string;
-      replacedBy: string[];
-    }
-  }
-}
-
 const configFiles = fs
   .readdirSync('.', { withFileTypes: true })
   .filter(value => value.isFile() && value.name.endsWith('.js'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,9 +1422,9 @@
       "dev": true
     },
     "@types/eslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.1.3.tgz",
-      "integrity": "sha512-llYf1QNZaDweXtA7uY6JczcwHmFwJL9TpK3E6sY0B18l6ulDT6VWNMAdEjYccFHiDfxLPxffd8QmSDV4QUUspA==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.1.6.tgz",
+      "integrity": "sha512-bTZQc4vx5zjlVWI8f+Ce1Ioc7o4RRi+qLhDXlHWIadmieyb6dZU4lxNFbWXd2l16+Izxw1Y6G0bG3ksi8W79dg==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@commitlint/config-conventional": "^8.3.4",
     "@semantic-release/changelog": "^3.0.6",
     "@semantic-release/git": "^7.0.18",
-    "@types/eslint": "^6.1.3",
+    "@types/eslint": "^6.1.6",
     "@types/jest": "^24.9.0",
     "@types/node": "^12.12.25",
     "@typescript-eslint/eslint-plugin": "^2.17.0",


### PR DESCRIPTION
[My PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41706) updating `@types/eslint` has been merged & published, so we don't need to argument the module ourselves.