### PR TITLE
Minor fixes

### DIFF
--- a/.eslintplugin/prefer-valid-rules.ts
+++ b/.eslintplugin/prefer-valid-rules.ts
@@ -14,7 +14,7 @@ const isNameOfESLintConfigFile = (fname: string): boolean =>
   configFiles.some(name => fname.endsWith(name));
 
 const compileConfigCode = (fileCode: string): ESLint.Linter.Config =>
-  runInNewContext(fileCode, { module: { exports: {} } }) ?? {};
+  runInNewContext(fileCode, { module: { exports: {} }, require }) ?? {};
 
 const createCLIEngine = (config: ESLint.Linter.Config): ESLint.CLIEngine =>
   new ESLint.CLIEngine({

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@commitlint/config-conventional": "^8.3.4",
     "@semantic-release/changelog": "^3.0.6",
     "@semantic-release/git": "^8.0.0",
-    "@types/eslint": "^6.1.6",
+    "@types/eslint": "^6.1.7",
     "@types/jest": "^24.9.1",
     "@types/node": "^12.12.25",
     "@typescript-eslint/eslint-plugin": "^2.17.0",


### PR DESCRIPTION
I didn't bump the actual version constraint for `@types/eslint`, and also forgot to pass `require` in the vm context for `prefer-valid-rules`.

The latter isn't needed unless `require` is actually used, which is why it didn't error in CI, but it's a nicity and I'm playing around with a new setup that'll use it so might as well just add it now and forget about it 🤷‍♂ 