### PR TITLE
fix(javascript): enable `allowWholeFile` for `disable-enable-pair`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const config = {
     'plugin:eslint-comments/recommended'
   ],
   rules: {
+    'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
     'eslint-comments/no-unused-disable': 'error',
     'import/export': 'error',
     'import/no-absolute-path': 'error',


### PR DESCRIPTION
This allows you to have `/* eslint-disable <rule> */` at the top of a file without requiring an `eslint-enable` at the end; if anything is above the `eslint-disable`, then the `eslint-enable` *is* required.

This is useful for the rare times we want to disable a rule for an entire file, such as with `no-sync` in scripts.