### PR TITLE
chore: update `.eslintignore`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 /node_modules/
 /coverage/
+/bundle/
+/vendor/
 /dist/
 /lib/
 /out/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install this package:
 
 ### Additional Setup
 
+#### `.eslintignore`
+
+You can use the `.eslintignore` file used by this repo. It includes relevant files for TypeScript, Ruby, and PHP projects.
+
 #### @typescript-eslint
 
 The `@typescript-eslint` configuration requires type checking to be setup.


### PR DESCRIPTION
@Rabid-Dan, @mischa-s, @greg-parsons

I'll move this into Ackama tomorrow-ish, and include this in the setup cli as well once it's committed, but for now this'll do.

It's just chore commits, as there's no major value in having it released by itself - I've got `@typescript-eslint/naming-convention` setup that I'm going to commit in a few days that'll be a patch release anyway 🤷‍♂ 